### PR TITLE
Handle auth and general plainly api errors

### DIFF
--- a/src/axiosConfig.ts
+++ b/src/axiosConfig.ts
@@ -33,30 +33,12 @@ export function createApiClient(config: {
           return Promise.reject(new PlainlyApiAuthenticationError(status));
         }
 
-        // Other server errors
+        // Other API errors
         if (status >= 400 && status < 600) {
           return Promise.reject(new PlainlyApiError(status, data?.message));
         }
-
-        // Other errors
-        if (status >= 400 && status < 600) {
-          const message =
-            data?.message || `API request failed with status ${status}`;
-          return Promise.reject({
-            status,
-            message,
-            details: data,
-          });
-        }
-
-        const message =
-          data?.message || `API request failed with status ${status}`;
-        return Promise.reject({
-          status,
-          message,
-          details: data,
-        });
       }
+      // Network or other errors
       return Promise.reject(error);
     }
   );

--- a/src/sdk/errors.ts
+++ b/src/sdk/errors.ts
@@ -1,0 +1,12 @@
+export class PlainlyApiError extends Error {
+  constructor(status: number, reason?: string) {
+    reason = reason || "Please contact support.";
+    super(`Plainly API error (status ${status}): ${reason}`);
+  }
+}
+
+export class PlainlyApiAuthenticationError extends PlainlyApiError {
+  constructor(status: number) {
+    super(status, "Authentication failed. Check your API key.");
+  }
+}


### PR DESCRIPTION
I think this is good enough:

<img width="505" height="307" alt="image" src="https://github.com/user-attachments/assets/116f42ea-273d-4cb0-a096-16e3a7d89c8d" />

Errors are automatically handled and converted to appropriate response, we just need to provide a meaningful messages.